### PR TITLE
Make poc1to2.pl more forgiving and helpful

### DIFF
--- a/poc1to2.pl/README.md
+++ b/poc1to2.pl/README.md
@@ -1,6 +1,32 @@
-
 ## PoC1 to PoC2 conversion
 
+```
+ Usage:
+    ./poc1to2.pl [options] <plotfile>
+
+ Options:
+    --help
+      This help
+
+    --mem <megabyte>
+      Memory constraint to use less memory than the script would have used
+      without any constraints (1/2000th of plot size)
+      Given in megabyte, so -m 1000 will use roughly 1GB of memory
+
+    --out <directory>
+      Define a directory to write the converted plot file to. This switches
+      to copy on write mode. (Else in-place is default) and allows you to
+      fasten up the conversion at the expense of temporary additional HDD
+      space.
+
+    --quiet
+      Quiet operation. Really quiet - no output at all (except failures).
+      You can send the process into background and forget about it.
+```
+
+## PoC2 to PoC1 conversion
+
+By specifying a PoC2 plot file instead of a PoC1 plot file, you could revert it back to PoC1.
 This is not the intended mode of operation, but it works nevertheless.
 
 It's possible, because PoC1 -> PoC2 conversion does not lose any

--- a/poc1to2.pl/poc1to2.pl
+++ b/poc1to2.pl/poc1to2.pl
@@ -36,9 +36,13 @@ GetOptions(
     'help'  => \&print_help,            # keep generated test files
     'out=s' => \$outdir,
     'quiet' => \$quiet,
-) or croak "Formal error processing command line options!";
+) or &print_help;
 
-my $plotpath = $ARGV[0];
+my $plotpath = shift @ARGV || do {
+	say STDERR "No plot file specified";
+	&print_help;
+	exit 1;
+};
 
 if (!-r $plotpath) {
     fail("Given plotfile '$plotpath' unreadable or nonexistant.");
@@ -242,7 +246,7 @@ sub print_help {
     $0 - PoC1 to PoC2 converter
 
  Usage:
-    $0 [options]
+    $0 [options] <plotfile>
 
  Options:
     --help


### PR DESCRIPTION
Just a few minor tweaks to make poc1to2.pl inform about required arguments, and print help text before aborting.

Running poc1to2.pl without any arguments at all would result in a few warnings before aborting:
```
$ ./poc1to2.pl
Use of uninitialized value $plotpath in -r at ./poc1to2.pl line 43.
Use of uninitialized value $plotpath in concatenation (.) or string at ./poc1to2.pl line 44.
Given plotfile '' unreadable or nonexistant.
```

This commit adds info about `<plotfile>` being a required argument, removes the perl warnings and makes the script print the help text before aborting:

```
$ ./poc1to2.pl
No plot file specified

    ./poc1to2.pl - PoC1 to PoC2 converter

 Usage:
    ./poc1to2.pl [options] <plotfile>
[...]
```

I also included the script's help text in a "PoC1 to PoC2 conversion"-section in README.md and reverted the "PoC2 to PoC1 conversion" header, since the actual description no longer matched the header.